### PR TITLE
Feat/GitHub workflow concurrency

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -11,6 +11,11 @@ env:
   ECR_REGISTRY: 151345152001.dkr.ecr.ap-northeast-2.amazonaws.com
   ECR_REPOSITORY: popo-admin-web
 
+# 같은 PR 안에서는 가장 최근 push만 워크플로우를 실행하도록 설정
+concurrency:
+  group: ${{ github.head_ref }} 
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run pre-commit
@@ -36,6 +41,10 @@ jobs:
     name: Docker build and push
     needs: lint
     runs-on: ubuntu-24.04-arm
+    # docker_build_and_push 잡은 모든 워크플로우에서 유일하게 하나만 실행되도록 설정
+    concurrency:
+      group: docker-build
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -1,9 +1,11 @@
+name: Docker Build and Push
+
 on:
-  push:
+  pull_request:
+    branches:
+      - main
   release:
     types: [published]
-
-name: Docker Build and Push
 
 env:
   ECR_REGISTRY: 151345152001.dkr.ecr.ap-northeast-2.amazonaws.com


### PR DESCRIPTION
워크플로우 트리거 조건 및 동시성 제어

- 이제 push가 아니라 PR을 열 때 워크플로우가 트리거 됨. PR이 올라간 뒤에는 push할 때마다 트리거 
  - 코드 변경을 dev에 반영하고 싶으면 PR을 올리자
  - 무지성 dev push x 로컬에서 테스트하고 올리자
  - 다른사람들이 어떤 작업을 하고 있는지 알 수 있음
  - 준비가 안되었다면 PR 올린 뒤 draft로 변경하고 계속 작업
- 같은 PR에서 워크플로우는 하나씩만 돌아감
  - push를 했는데 워크플로우가 이미 돌고있다? 그거 캔슬함
  - 서로 다른 PR에서는 상관 X
- `docker_build_and_push` 잡은 모든 워크플로우 통틀어서 유일하게 하나만 돌아감
  - 도커 이미지 빌드&원격 push 동시에 해서 swarm에서 latest 가져오는게 뭔가 꼬였던 것 같아서 이렇게 설정했음