### PR TITLE
Feat: Delete past docker images after deploying dev

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -104,6 +104,16 @@ jobs:
             exit 1
           fi
           echo "✅ Deployment successful! HTTP Response: $RESPONSE"
+        # 머신에 사용되지 않는 이미지 쌓여서 디스크 부족해지는 것을 방지하기 위해 삭제
+      - name: Clean up old Docker images on EC2 (only for dev)
+        if: success() 
+        uses: appleboy/ssh-action@1.2.2
+        with:
+          host: ${{ secrets.POPO_EC2_HOSTNAME }}
+          username: ${{ secrets.POPO_EC2_USERNAME }}
+          key: ${{ secrets.POPO_EC2_SSH_KEY }}
+          script: |
+            docker image prune -af
 
   deploy_health_check:
     name: Check Application Status

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -107,7 +107,7 @@ jobs:
         # 머신에 사용되지 않는 이미지 쌓여서 디스크 부족해지는 것을 방지하기 위해 삭제
       - name: Clean up old Docker images on EC2 (only for dev)
         if: success()
-        uses: appleboy/ssh-action@1.2.2
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.POPO_EC2_HOSTNAME }}
           username: ${{ secrets.POPO_EC2_USERNAME }}

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -113,7 +113,7 @@ jobs:
           username: ${{ secrets.POPO_EC2_USERNAME }}
           key: ${{ secrets.POPO_EC2_SSH_KEY }}
           script: |
-            docker image prune -af
+            docker system prune -af
 
   deploy_health_check:
     name: Check Application Status

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -106,7 +106,7 @@ jobs:
           echo "✅ Deployment successful! HTTP Response: $RESPONSE"
         # 머신에 사용되지 않는 이미지 쌓여서 디스크 부족해지는 것을 방지하기 위해 삭제
       - name: Clean up old Docker images on EC2 (only for dev)
-        if: success() 
+        if: success()
         uses: appleboy/ssh-action@1.2.2
         with:
           host: ${{ secrets.POPO_EC2_HOSTNAME }}

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -113,9 +113,12 @@ jobs:
           username: ${{ secrets.POPO_EC2_USERNAME }}
           key: ${{ secrets.POPO_EC2_SSH_KEY }}
           script: |
-            echo "컨테이너/이미지 확인"
+            echo "::group::컨테이너 확인"
             docker ps -a
+            echo "::endgroup::"
+            echo "::group::이미지 확인"
             docker images
+            echo "::endgroup::"
             echo "사용하지 않는 이미지 및 컨테이너 제거"
             docker system prune -af
 

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -113,6 +113,10 @@ jobs:
           username: ${{ secrets.POPO_EC2_USERNAME }}
           key: ${{ secrets.POPO_EC2_SSH_KEY }}
           script: |
+            echo "컨테이너/이미지 확인"
+            docker ps -a
+            docker images
+            echo "사용하지 않는 이미지 및 컨테이너 제거"
             docker system prune -af
 
   deploy_health_check:


### PR DESCRIPTION
원래는 머신에서 이미지 정리 명령을 몇 분 주기로 실행했는데 그럴 필요없이 CI/CD 단계에서 이미지 교체될 때만 명시적으로 삭제하도록 변경 

### Action에서 dev deploy 후 필요없는 컨테이너/이미지 삭제된 모습
https://github.com/PoApper/popo-admin-web/actions/runs/17797718960
<img width="1234" height="614" alt="image" src="https://github.com/user-attachments/assets/2dbe943f-63df-47f6-b35e-26e52d03f99b" />
