### PR TITLE
fix: PAXI 방 상세 정보의 삭제 버튼 제거

### DIFF
--- a/pages/paxi/index.jsx
+++ b/pages/paxi/index.jsx
@@ -738,9 +738,9 @@ const PaxiManagementPage = () => {
           )}
         </Modal.Content>
         <Modal.Actions>
-          <Button negative onClick={handleDeleteClick}>
+          {/*<Button negative onClick={handleDeleteClick}>
             방 삭제
-          </Button>
+          </Button>*/}
           <Button primary onClick={handleEditClick}>
             수정하기
           </Button>

--- a/pages/paxi/index.jsx
+++ b/pages/paxi/index.jsx
@@ -355,9 +355,9 @@ const PaxiManagementPage = () => {
   };
 
   // 삭제 모달 열기
-  const handleDeleteClick = () => {
-    setDeleteModalOpen(true);
-  };
+  // const handleDeleteClick = () => {
+  // setDeleteModalOpen(true);
+  // };
 
   // 삭제 확인
   const handleConfirmDelete = async () => {


### PR DESCRIPTION
어드민 페이지의 카풀(PAXI) 관리 화면에서, 카풀 방에 있는 [방 삭제] 버튼을 주석 처리하여 제거했습니다.