### PR TITLE
비교과활동 / 활동 수기 관리 페이지

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -101,7 +101,11 @@ const MobileNav = () => {
                   </Link>
                 </Dropdown.Item>
                 <Dropdown.Item>
-                  <Link href={'/extracurricular'} passHref style={{ color: 'black' }}>
+                  <Link
+                    href={'/extracurricular'}
+                    passHref
+                    style={{ color: 'black' }}
+                  >
                     비교과활동 관리
                   </Link>
                 </Dropdown.Item>

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -101,6 +101,11 @@ const MobileNav = () => {
                   </Link>
                 </Dropdown.Item>
                 <Dropdown.Item>
+                  <Link href={'/extracurricular'} passHref style={{ color: 'black' }}>
+                    비교과활동 관리
+                  </Link>
+                </Dropdown.Item>
+                <Dropdown.Item>
                   <Link
                     href={'/statistics'}
                     passHref
@@ -166,6 +171,11 @@ const DesktopNav = () => {
         <Menu.Item>
           <Link href={'/paxi'} passHref style={{ color: 'black' }}>
             카풀 관리
+          </Link>
+        </Menu.Item>
+        <Menu.Item>
+          <Link href={'/extracurricular'} passHref style={{ color: 'black' }}>
+            비교과활동 관리
           </Link>
         </Menu.Item>
         <Menu.Item>

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -11,7 +11,7 @@ import {
   Icon,
   Message,
 } from 'semantic-ui-react';
-import Navbar from '../../components/navbar/navbar';
+import LayoutWithAuth from '@/components/layout/layout.auth.with';
 import { PoPoAxios } from '../../utils/axios.instance';
 
 // 쓰기 요청은 관리자/자치단체 권한이 필요하다. PoPoAxios 는 withCredentials 로
@@ -230,8 +230,18 @@ export default function AdminExtracurricularPage() {
   };
 
   const handleSaveReport = async () => {
-    if (!repForm.title || !repForm.activityId) {
-      alert('보고서 제목과 활동 선택은 필수 항목입니다.');
+    if (!repForm.title) {
+      alert('보고서 제목은 필수 항목입니다.');
+      return;
+    }
+
+    if (!repForm.activityId) {
+      alert('활동 선택은 필수 항목입니다.');
+      return;
+    }
+
+    if (!repForm.period) {
+      alert('수행 시기는 필수 항목입니다.');
       return;
     }
 
@@ -376,9 +386,11 @@ export default function AdminExtracurricularPage() {
                 <Table.HeaderCell>보고서 제목</Table.HeaderCell>
                 <Table.HeaderCell>수행 시기</Table.HeaderCell>
                 <Table.HeaderCell>전공 / 학년</Table.HeaderCell>
-                <Table.HeaderCell>작성자</Table.HeaderCell>
+                <Table.HeaderCell style={{ width: 60 }}>
+                  작성자
+                </Table.HeaderCell>
                 <Table.HeaderCell>파일명</Table.HeaderCell>
-                <Table.HeaderCell style={{ width: 120 }}>관리</Table.HeaderCell>
+                <Table.HeaderCell style={{ width: 100 }}>관리</Table.HeaderCell>
               </Table.Row>
             </Table.Header>
 
@@ -425,10 +437,9 @@ export default function AdminExtracurricularPage() {
   ];
 
   return (
-    <>
-      <Navbar />
+    <LayoutWithAuth>
       <Container>
-        <Segment basic style={{ marginTop: 80 }}>
+        <Segment basic>
           <Header as="h2">
             <Icon name="book" />
             <Header.Content>
@@ -561,7 +572,7 @@ export default function AdminExtracurricularPage() {
                     }
                   />
                   <Form.Input
-                    label="수기/보고서 제목"
+                    label="수기/보고서 제목*"
                     placeholder="예: 2025 유럽 탄소중립 교통 탐방 보고서"
                     value={repForm.title}
                     onChange={(e) =>
@@ -580,7 +591,7 @@ export default function AdminExtracurricularPage() {
                     }
                   />
                   <Form.Input
-                    label="전공"
+                    label="전공 (선택)"
                     placeholder="예: 컴퓨터공학과"
                     value={repForm.major}
                     onChange={(e) =>
@@ -588,7 +599,7 @@ export default function AdminExtracurricularPage() {
                     }
                   />
                   <Form.Input
-                    label="학년"
+                    label="학년 (선택)"
                     placeholder="예: 3학년"
                     value={repForm.grade}
                     onChange={(e) =>
@@ -596,7 +607,7 @@ export default function AdminExtracurricularPage() {
                     }
                   />
                   <Form.Input
-                    label="작성자 (익명)"
+                    label="작성자 (선택)"
                     placeholder="예: 김*훈"
                     value={repForm.author}
                     onChange={(e) =>
@@ -668,7 +679,7 @@ export default function AdminExtracurricularPage() {
           </Modal>
         </Segment>
       </Container>
-    </>
+    </LayoutWithAuth>
   );
 }
 

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -25,12 +25,15 @@ const errorMessageOf = (err) => {
   );
 };
 
-const categoryOptions = [
-  { key: 'global', text: '글로벌/해외', value: '글로벌/해외' },
-  { key: 'academic', text: '학술/연구', value: '학술/연구' },
-  { key: 'volunteer', text: '봉사/사회공헌', value: '봉사/사회공헌' },
-  { key: 'startup', text: '창업/취업', value: '창업/취업' },
-];
+// 카테고리는 하드코딩하지 않고 등록된 활동에서 뽑는다.
+// 신규 카테고리는 드롭다운에 직접 입력해서 추가할 수 있다(allowAdditions).
+const toCategoryOptions = (activities, extra) => {
+  const set = new Set(activities.map((a) => a.category).filter(Boolean));
+  if (extra) set.add(extra);
+  return Array.from(set)
+    .sort((a, b) => a.localeCompare(b, 'ko'))
+    .map((c) => ({ key: c, text: c, value: c }));
+};
 
 const fileTypeOptions = [
   { key: 'pdf', text: 'PDF', value: 'pdf' },
@@ -63,7 +66,7 @@ export default function AdminExtracurricularPage() {
     target: '',
     applicationMethod: '',
     description: '',
-    category: '글로벌/해외',
+    category: '',
   });
 
   // Report Modal State
@@ -114,7 +117,7 @@ export default function AdminExtracurricularPage() {
         target: '',
         applicationMethod: '',
         description: '',
-        category: '글로벌/해외',
+        category: '',
       });
     }
     setIsActModalOpen(true);
@@ -430,11 +433,18 @@ export default function AdminExtracurricularPage() {
                   />
                   <Form.Select
                     label="카테고리"
-                    options={categoryOptions}
+                    options={toCategoryOptions(activities, actForm.category)}
                     value={actForm.category}
+                    search
+                    allowAdditions
+                    additionLabel="새 카테고리 추가: "
+                    onAddItem={(e, { value }) =>
+                      setActForm({ ...actForm, category: value })
+                    }
                     onChange={(e, { value }) =>
                       setActForm({ ...actForm, category: value })
                     }
+                    placeholder="카테고리 선택 또는 새로 입력"
                   />
                 </Form.Group>
 

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -10,6 +10,7 @@ import {
   Tab,
   Icon,
   Message,
+  Progress,
 } from 'semantic-ui-react';
 import LayoutWithAuth from '@/components/layout/layout.auth.with';
 import { PoPoAxios } from '../../utils/axios.instance';
@@ -88,6 +89,158 @@ export default function AdminExtracurricularPage() {
   const [pickedFile, setPickedFile] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef(null);
+
+  // Bulk Report Modal State
+  const [isBulkModalOpen, setIsBulkModalOpen] = useState(false);
+  const [bulkActivityId, setBulkActivityId] = useState('');
+  const [bulkPeriod, setBulkPeriod] = useState('');
+  const [stagedFiles, setStagedFiles] = useState([]);
+  const [isBulkUploading, setIsBulkUploading] = useState(false);
+  const [bulkProgress, setBulkProgress] = useState({ current: 0, total: 0 });
+  const [isBulkDragging, setIsBulkDragging] = useState(false);
+  const bulkFileInputRef = useRef(null);
+
+  const handleOpenBulkModal = () => {
+    setBulkActivityId(activities[0]?.uuid || '');
+    setBulkPeriod('');
+    setStagedFiles([]);
+    setIsBulkUploading(false);
+    setBulkProgress({ current: 0, total: 0 });
+    setIsBulkDragging(false);
+    setIsBulkModalOpen(true);
+  };
+
+  const closeBulkModal = () => {
+    if (isBulkUploading) return;
+    setIsBulkModalOpen(false);
+    setStagedFiles([]);
+    setIsBulkDragging(false);
+  };
+
+  const applyBulkFiles = (files) => {
+    if (!files || files.length === 0) return;
+    const fileArray = Array.from(files);
+    const validFiles = fileArray.filter((file) => {
+      const ext = file.name.split('.').pop()?.toLowerCase();
+      return ACCEPTED_EXTENSIONS.includes(ext);
+    });
+
+    if (validFiles.length < fileArray.length) {
+      alert(
+        `일부 파일은 지원하지 않는 확장자입니다. (${ACCEPTED_EXTENSIONS.join(
+          ', ',
+        )}만 허용)`,
+      );
+    }
+
+    const newItems = validFiles.map((file) => ({
+      id: `${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
+      file,
+      title: baseNameOf(file.name),
+      author: '',
+      major: '',
+      grade: '',
+      memo: '',
+      status: 'pending',
+      errorMsg: '',
+    }));
+
+    setStagedFiles((prev) => [...prev, ...newItems]);
+  };
+
+  const handleBulkDrop = (e) => {
+    e.preventDefault();
+    setIsBulkDragging(false);
+    applyBulkFiles(e.dataTransfer.files);
+  };
+
+  const handleRemoveStagedFile = (id) => {
+    setStagedFiles((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const handleUpdateStagedFileTitle = (id, title) => {
+    setStagedFiles((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, title } : item)),
+    );
+  };
+
+  const handleBulkSave = async () => {
+    if (!bulkActivityId) {
+      alert('연관 비교과활동을 선택해 주세요.');
+      return;
+    }
+    if (!bulkPeriod) {
+      alert('수행 시기를 입력해 주세요.');
+      return;
+    }
+    if (stagedFiles.length === 0) {
+      alert('업로드할 파일을 1개 이상 추가해 주세요.');
+      return;
+    }
+
+    const emptyTitleItem = stagedFiles.find((item) => !item.title.trim());
+    if (emptyTitleItem) {
+      alert(`[${emptyTitleItem.file.name}]의 보고서 제목을 입력해 주세요.`);
+      return;
+    }
+
+    setIsBulkUploading(true);
+    setBulkProgress({ current: 0, total: stagedFiles.length });
+
+    let successCount = 0;
+    let failCount = 0;
+
+    for (let i = 0; i < stagedFiles.length; i++) {
+      const item = stagedFiles[i];
+
+      setStagedFiles((prev) =>
+        prev.map((f) => (f.id === item.id ? { ...f, status: 'uploading' } : f)),
+      );
+
+      const payload = new FormData();
+      payload.append('activityId', bulkActivityId);
+      payload.append('period', bulkPeriod);
+      payload.append('title', item.title);
+      payload.append('grade', item.grade || '');
+      payload.append('major', item.major || '');
+      payload.append('author', item.author || '');
+      payload.append('memo', item.memo || '');
+      payload.append('file', item.file);
+
+      try {
+        await PoPoAxios.post('/activity-report', payload);
+        successCount++;
+        setStagedFiles((prev) =>
+          prev.map((f) => (f.id === item.id ? { ...f, status: 'success' } : f)),
+        );
+      } catch (err) {
+        failCount++;
+        const msg = errorMessageOf(err);
+        setStagedFiles((prev) =>
+          prev.map((f) =>
+            f.id === item.id ? { ...f, status: 'error', errorMsg: msg } : f,
+          ),
+        );
+      }
+
+      setBulkProgress({ current: i + 1, total: stagedFiles.length });
+    }
+
+    setIsBulkUploading(false);
+
+    if (failCount === 0) {
+      notify(
+        `총 ${successCount}개의 활동 보고서가 성공적으로 일괄 업로드되었습니다.`,
+      );
+      closeBulkModal();
+      await fetchData();
+    } else {
+      notifyError(
+        `일괄 업로드 완료: 성공 ${successCount}건, 실패 ${failCount}건. 실패한 항목을 확인해 주세요.`,
+      );
+      await fetchData();
+    }
+  };
 
   /** 파일을 고르면 제목을 확장자 뺀 파일명으로 자동 채운다. */
   const applyPickedFile = (file) => {
@@ -364,19 +517,33 @@ export default function AdminExtracurricularPage() {
             style={{
               display: 'flex',
               justifyContent: 'space-between',
+              alignItems: 'center',
               marginBottom: 16,
             }}
           >
-            <Header as="h3">등록된 보고서 및 수기 ({reports.length}개)</Header>
-            <Button
-              color="green"
-              icon
-              labelPosition="left"
-              onClick={() => handleOpenRepModal()}
-            >
-              <Icon name="upload" />
-              신규 보고서 수기 업로드
-            </Button>
+            <Header as="h3" style={{ margin: 0 }}>
+              등록된 보고서 및 수기 ({reports.length}개)
+            </Header>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Button
+                color="teal"
+                icon
+                labelPosition="left"
+                onClick={handleOpenBulkModal}
+              >
+                <Icon name="file archive" />
+                일괄 보고서 업로드
+              </Button>
+              <Button
+                color="green"
+                icon
+                labelPosition="left"
+                onClick={() => handleOpenRepModal()}
+              >
+                <Icon name="upload" />
+                신규 보고서 수기 업로드
+              </Button>
+            </div>
           </div>
 
           <Table celled striped>
@@ -384,7 +551,7 @@ export default function AdminExtracurricularPage() {
               <Table.Row>
                 <Table.HeaderCell>연관 활동</Table.HeaderCell>
                 <Table.HeaderCell>보고서 제목</Table.HeaderCell>
-                <Table.HeaderCell>수행 시기</Table.HeaderCell>
+                <Table.HeaderCell>수행 시기*</Table.HeaderCell>
                 <Table.HeaderCell>전공 / 학년</Table.HeaderCell>
                 <Table.HeaderCell style={{ width: 60 }}>
                   작성자
@@ -674,6 +841,230 @@ export default function AdminExtracurricularPage() {
               <Button onClick={closeRepModal}>취소</Button>
               <Button positive onClick={handleSaveReport}>
                 저장
+              </Button>
+            </Modal.Actions>
+          </Modal>
+
+          {/* Bulk Report Modal */}
+          <Modal open={isBulkModalOpen} onClose={closeBulkModal} size="large">
+            <Modal.Header>
+              <Icon name="file archive" /> 활동 보고서 일괄 업로드
+            </Modal.Header>
+            <Modal.Content scrolling>
+              <Message info style={{ marginBottom: 16 }}>
+                <Message.Header>일괄 업로드 안내</Message.Header>
+                <p>
+                  동일한 활동 및 수행 시기에 해당하는 보고서 문서 파일들을
+                  한꺼번에 올릴 수 있습니다.
+                  <br />각 파일의 기본 제목은 파일명(확장자 제외)으로 자동
+                  입력되며, 필요 시 목록에서 직접 수정 가능합니다.
+                </p>
+              </Message>
+
+              <Form>
+                <Form.Group widths="equal">
+                  <Form.Select
+                    label="연관 비교과활동 (필수)"
+                    options={activities.map((a) => ({
+                      key: a.uuid,
+                      text: a.title,
+                      value: a.uuid,
+                    }))}
+                    value={bulkActivityId}
+                    onChange={(e, { value }) => setBulkActivityId(value)}
+                    placeholder="활동 선택"
+                    disabled={isBulkUploading}
+                  />
+                  <Form.Input
+                    label="수행 시기 (필수)"
+                    placeholder="예: 2025학년도 하계"
+                    value={bulkPeriod}
+                    onChange={(e) => setBulkPeriod(e.target.value)}
+                    disabled={isBulkUploading}
+                  />
+                </Form.Group>
+
+                <Form.Field>
+                  <label>원본 문서들 (다중 선택 및 파일 드롭 가능)</label>
+                  <DropZone
+                    dragging={isBulkDragging}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setIsBulkDragging(true);
+                    }}
+                    onDragLeave={() => setIsBulkDragging(false)}
+                    onDrop={handleBulkDrop}
+                    onClick={() => {
+                      if (!isBulkUploading) bulkFileInputRef.current?.click();
+                    }}
+                  >
+                    <Icon name="cloud upload" size="big" />
+                    <strong>
+                      여기로 파일들을 끌어다 놓으세요 (다중 선택 가능)
+                    </strong>
+                    <small>또는 클릭해서 찾아보기 (PDF, DOCX, HWPX 등)</small>
+                  </DropZone>
+
+                  <input
+                    ref={bulkFileInputRef}
+                    type="file"
+                    multiple
+                    accept={ACCEPTED_EXTENSIONS.map((e) => `.${e}`).join(',')}
+                    hidden
+                    onChange={(e) => {
+                      applyBulkFiles(e.target.files);
+                      e.target.value = '';
+                    }}
+                  />
+                </Form.Field>
+
+                {isBulkUploading && (
+                  <Segment style={{ marginTop: 16 }}>
+                    <Header as="h5">업로드 진행 중...</Header>
+                    <Progress
+                      percent={
+                        bulkProgress.total > 0
+                          ? Math.round(
+                              (bulkProgress.current / bulkProgress.total) * 100,
+                            )
+                          : 0
+                      }
+                      progress
+                      indicating
+                    />
+                  </Segment>
+                )}
+
+                {stagedFiles.length > 0 && (
+                  <Segment style={{ marginTop: 16 }}>
+                    <Header as="h4">
+                      업로드 대상 파일 목록 ({stagedFiles.length}개)
+                    </Header>
+                    <Table celled compact striped>
+                      <Table.Header>
+                        <Table.Row>
+                          <Table.HeaderCell style={{ width: 40 }}>
+                            #
+                          </Table.HeaderCell>
+                          <Table.HeaderCell style={{ width: '30%' }}>
+                            파일명 / 크기
+                          </Table.HeaderCell>
+                          <Table.HeaderCell>
+                            보고서 제목 (수정 가능)*
+                          </Table.HeaderCell>
+                          <Table.HeaderCell style={{ width: 80 }}>
+                            상태
+                          </Table.HeaderCell>
+                          <Table.HeaderCell style={{ width: 60 }}>
+                            삭제
+                          </Table.HeaderCell>
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        {stagedFiles.map((item, idx) => (
+                          <Table.Row
+                            key={item.id}
+                            negative={item.status === 'error'}
+                            positive={item.status === 'success'}
+                          >
+                            <Table.Cell>{idx + 1}</Table.Cell>
+                            <Table.Cell>
+                              <div
+                                style={{
+                                  wordBreak: 'break-all',
+                                  fontWeight: 'bold',
+                                }}
+                              >
+                                {item.file.name}
+                              </div>
+                              <small style={{ color: '#666' }}>
+                                {(item.file.size / 1024 / 1024).toFixed(2)} MB
+                              </small>
+                            </Table.Cell>
+                            <Table.Cell>
+                              <Form.Input
+                                value={item.title}
+                                disabled={isBulkUploading}
+                                onChange={(e) =>
+                                  handleUpdateStagedFileTitle(
+                                    item.id,
+                                    e.target.value,
+                                  )
+                                }
+                                placeholder="보고서 제목"
+                                error={!item.title.trim()}
+                              />
+                              {item.errorMsg && (
+                                <div
+                                  style={{
+                                    color: '#db2828',
+                                    fontSize: '0.85rem',
+                                    marginTop: 4,
+                                  }}
+                                >
+                                  {item.errorMsg}
+                                </div>
+                              )}
+                            </Table.Cell>
+                            <Table.Cell textAlign="center">
+                              {item.status === 'pending' && (
+                                <Icon
+                                  name="clock outline"
+                                  color="grey"
+                                  title="대기 중"
+                                />
+                              )}
+                              {item.status === 'uploading' && (
+                                <Icon
+                                  name="spinner"
+                                  loading
+                                  color="blue"
+                                  title="업로드 중"
+                                />
+                              )}
+                              {item.status === 'success' && (
+                                <Icon
+                                  name="check circle"
+                                  color="green"
+                                  title="완료"
+                                />
+                              )}
+                              {item.status === 'error' && (
+                                <Icon
+                                  name="warning sign"
+                                  color="red"
+                                  title="실패"
+                                />
+                              )}
+                            </Table.Cell>
+                            <Table.Cell textAlign="center">
+                              <Button
+                                icon="trash"
+                                color="red"
+                                size="tiny"
+                                disabled={isBulkUploading}
+                                onClick={() => handleRemoveStagedFile(item.id)}
+                              />
+                            </Table.Cell>
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table>
+                  </Segment>
+                )}
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button onClick={closeBulkModal} disabled={isBulkUploading}>
+                취소
+              </Button>
+              <Button
+                color="teal"
+                loading={isBulkUploading}
+                disabled={isBulkUploading || stagedFiles.length === 0}
+                onClick={handleBulkSave}
+              >
+                <Icon name="upload" /> 일괄 업로드 시작 ({stagedFiles.length}개)
               </Button>
             </Modal.Actions>
           </Modal>

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -5,9 +5,6 @@ import {
   Table,
   Modal,
   Form,
-  Input,
-  TextArea,
-  Select,
   Header,
   Segment,
   Tab,
@@ -15,6 +12,18 @@ import {
   Message,
 } from 'semantic-ui-react';
 import Navbar from '../../components/navbar/navbar';
+import { PoPoAxios } from '../../utils/axios.instance';
+
+// 쓰기 요청은 관리자/자치단체 권한이 필요하다. PoPoAxios 는 withCredentials 로
+// 인증 쿠키를 함께 보내므로, 생 fetch 를 쓰면 401 이 난다.
+const errorMessageOf = (err) => {
+  const status = err?.response?.status;
+  if (status === 401) return '로그인이 필요합니다. 다시 로그인해주세요.';
+  if (status === 403) return '권한이 없습니다. 관리자 계정으로 로그인해주세요.';
+  return (
+    err?.response?.data?.message ?? err?.message ?? '알 수 없는 오류입니다.'
+  );
+};
 
 const categoryOptions = [
   { key: 'global', text: '글로벌/해외', value: '글로벌/해외' },
@@ -29,48 +38,21 @@ const fileTypeOptions = [
   { key: 'hwpx', text: 'HWPX', value: 'hwpx' },
 ];
 
-const INITIAL_ACTIVITIES = [
-  {
-    uuid: 'act-01',
-    title: '세계문화탐방대',
-    period: '매년 하계/동계 방학 중 (연 2회)',
-    target: '학부 재학생 (직전 학기 평점 3.0 이상)',
-    applicationMethod: '지원서 및 탐방 계획서 작성 후 포털 접수 -> 서류 심사 -> 면접 전형',
-    description: '학생들이 직접 탐방 주제와 국가를 선정하고 문화, 사회, 학문 분야의 연구 과제를 직접 체험하고 분석하는 글로벌 도전 프로그램입니다.',
-    category: '글로벌/해외',
-  },
-  {
-    uuid: 'act-02',
-    title: '노벨 위크 탐방단',
-    period: '매년 10월 ~ 11월 중 모집',
-    target: '이공계열 및 인문사회계열 학부 2~4학년',
-    applicationMethod: '노벨상 관련 에세이 제출 -> 심사 -> 학과장 추천 및 면접',
-    description: '스웨덴 스톡홀름에서 열리는 노벨상 시상식 주간에 현지를 방문하여 노벨 재단 강연 참석, 스웨덴 명문대 학생들과의 학술 교류 등을 진행하는 최고 권위의 학술 탐방 프로그램입니다.',
-    category: '학술/연구',
-  },
-];
-
-const INITIAL_REPORTS = [
-  {
-    uuid: 'rep-01',
-    activityId: 'act-01',
-    title: '유럽 친환경 도시 설계 및 탄소중립 교통 시스템 탐방 보고서',
-    period: '2025학년도 하계',
-    grade: '3학년',
-    major: '도시공학과',
-    author: '민*우',
-    wordsToJuniors: '현지 전문가 인터뷰나 기관 방문 메일을 최소 한 달 전부터 꼼꼼히 보내두는 게 좋습니다.',
-    aiSummary: '독일 프라이부르크와 네덜란드 암스테르담의 친환경 대중교통 인프라 탐방 결과 보고서.',
-    fileName: '2025_하계_세계문화탐방대_유럽교통보고서.pdf',
-    fileType: 'pdf',
-  },
-];
-
 export default function AdminExtracurricularPage() {
-  const [activities, setActivities] = useState(INITIAL_ACTIVITIES);
-  const [reports, setReports] = useState(INITIAL_REPORTS);
+  const [activities, setActivities] = useState([]);
+  const [reports, setReports] = useState([]);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState(null);
+  const [isError, setIsError] = useState(false);
+
+  const notify = (text) => {
+    setIsError(false);
+    setMessage(text);
+  };
+  const notifyError = (text) => {
+    setIsError(true);
+    setMessage(text);
+  };
 
   // Activity Modal State
   const [isActModalOpen, setIsActModalOpen] = useState(false);
@@ -100,8 +82,6 @@ export default function AdminExtracurricularPage() {
     fileType: 'pdf',
   });
 
-  const apiUrl = process.env.NEXT_PUBLIC_API || 'https://api.popo-dev.poapper.club';
-
   useEffect(() => {
     fetchData();
   }, []);
@@ -109,23 +89,14 @@ export default function AdminExtracurricularPage() {
   const fetchData = async () => {
     setLoading(true);
     try {
-      const actRes = await fetch(`${apiUrl}/activity`);
-      if (actRes.ok) {
-        const actData = await actRes.json();
-        if (Array.isArray(actData) && actData.length > 0) {
-          setActivities(actData);
-        }
-      }
-
-      const repRes = await fetch(`${apiUrl}/activity-report`);
-      if (repRes.ok) {
-        const repData = await repRes.json();
-        if (Array.isArray(repData) && repData.length > 0) {
-          setReports(repData);
-        }
-      }
+      const [actRes, repRes] = await Promise.all([
+        PoPoAxios.get('/activity'),
+        PoPoAxios.get('/activity-report'),
+      ]);
+      setActivities(Array.isArray(actRes.data) ? actRes.data : []);
+      setReports(Array.isArray(repRes.data) ? repRes.data : []);
     } catch (err) {
-      console.log('Failed fetching admin data from API, using state fallback:', err);
+      notifyError(`목록을 불러오지 못했습니다. ${errorMessageOf(err)}`);
     } finally {
       setLoading(false);
     }
@@ -155,63 +126,46 @@ export default function AdminExtracurricularPage() {
       return;
     }
 
+    // uuid 는 서버가 발급한다. 클라이언트에서 만들어 보내지 않는다.
+    const { uuid } = actForm;
+    const payload = {
+      title: actForm.title,
+      period: actForm.period,
+      target: actForm.target,
+      applicationMethod: actForm.applicationMethod,
+      description: actForm.description,
+      category: actForm.category,
+    };
+
     try {
-      if (actForm.uuid) {
-        // Update
-        const res = await fetch(`${apiUrl}/activity/${actForm.uuid}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(actForm),
-        });
-        if (res.ok) {
-          setMessage('비교과활동 정보가 수정되었습니다.');
-        }
-        setActivities((prev) =>
-          prev.map((a) => (a.uuid === actForm.uuid ? { ...a, ...actForm } : a))
-        );
+      if (uuid) {
+        await PoPoAxios.patch(`/activity/${uuid}`, payload);
+        notify('비교과활동 정보가 수정되었습니다.');
       } else {
-        // Create
-        const newUuid = `act-${Date.now()}`;
-        const newAct = { ...actForm, uuid: newUuid };
-        const res = await fetch(`${apiUrl}/activity`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(newAct),
-        });
-        if (res.ok) {
-          const created = await res.json();
-          setActivities((prev) => [created, ...prev]);
-        } else {
-          setActivities((prev) => [newAct, ...prev]);
-        }
-        setMessage('신규 비교과활동이 등록되었습니다.');
+        await PoPoAxios.post('/activity', payload);
+        notify('신규 비교과활동이 등록되었습니다.');
       }
-    } catch (err) {
-      console.log('API call fallback during save:', err);
-      const newUuid = actForm.uuid || `act-${Date.now()}`;
-      setActivities((prev) => {
-        const exists = prev.some((a) => a.uuid === newUuid);
-        if (exists) {
-          return prev.map((a) => (a.uuid === newUuid ? { ...a, ...actForm } : a));
-        }
-        return [{ ...actForm, uuid: newUuid }, ...prev];
-      });
-      setMessage('저장되었습니다 (로컬 상태 반영).');
-    } finally {
       setIsActModalOpen(false);
+      await fetchData();
+    } catch (err) {
+      notifyError(`저장하지 못했습니다. ${errorMessageOf(err)}`);
     }
   };
 
   const handleDeleteActivity = async (uuid) => {
-    if (!confirm('정말 이 비교과활동을 삭제하시겠습니까? 연결된 보고서도 함께 삭제될 수 있습니다.'))
+    if (
+      !confirm(
+        '정말 이 비교과활동을 삭제하시겠습니까? 연결된 보고서도 함께 삭제될 수 있습니다.',
+      )
+    )
       return;
     try {
-      await fetch(`${apiUrl}/activity/${uuid}`, { method: 'DELETE' });
-    } catch (e) {
-      console.log('API delete fallback:', e);
+      await PoPoAxios.delete(`/activity/${uuid}`);
+      notify('비교과활동이 삭제되었습니다.');
+      await fetchData();
+    } catch (err) {
+      notifyError(`삭제하지 못했습니다. ${errorMessageOf(err)}`);
     }
-    setActivities((prev) => prev.filter((a) => a.uuid !== uuid));
-    setMessage('비교과활동이 삭제되었습니다.');
   };
 
   // Report Handlers
@@ -242,60 +196,44 @@ export default function AdminExtracurricularPage() {
       return;
     }
 
+    const { uuid } = repForm;
+    const payload = {
+      activityId: repForm.activityId,
+      title: repForm.title,
+      period: repForm.period,
+      grade: repForm.grade,
+      major: repForm.major,
+      author: repForm.author,
+      wordsToJuniors: repForm.wordsToJuniors,
+      aiSummary: repForm.aiSummary,
+      fileName: repForm.fileName,
+      fileType: repForm.fileType,
+    };
+
     try {
-      if (repForm.uuid) {
-        // Update
-        await fetch(`${apiUrl}/activity-report/${repForm.uuid}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(repForm),
-        });
-        setReports((prev) =>
-          prev.map((r) => (r.uuid === repForm.uuid ? { ...r, ...repForm } : r))
-        );
-        setMessage('보고서 수기가 수정되었습니다.');
+      if (uuid) {
+        await PoPoAxios.patch(`/activity-report/${uuid}`, payload);
+        notify('보고서 수기가 수정되었습니다.');
       } else {
-        // Create
-        const newUuid = `rep-${Date.now()}`;
-        const newRep = { ...repForm, uuid: newUuid };
-        const res = await fetch(`${apiUrl}/activity-report`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(newRep),
-        });
-        if (res.ok) {
-          const created = await res.json();
-          setReports((prev) => [created, ...prev]);
-        } else {
-          setReports((prev) => [newRep, ...prev]);
-        }
-        setMessage('신규 보고서 수기가 등록되었습니다.');
+        await PoPoAxios.post('/activity-report', payload);
+        notify('신규 보고서 수기가 등록되었습니다.');
       }
-    } catch (err) {
-      console.log('API report save fallback:', err);
-      const newUuid = repForm.uuid || `rep-${Date.now()}`;
-      setReports((prev) => {
-        const exists = prev.some((r) => r.uuid === newUuid);
-        if (exists) {
-          return prev.map((r) => (r.uuid === newUuid ? { ...r, ...repForm } : r));
-        }
-        return [{ ...repForm, uuid: newUuid }, ...prev];
-      });
-      setMessage('저장되었습니다 (로컬 상태 반영).');
-    } finally {
       setIsRepModalOpen(false);
+      await fetchData();
+    } catch (err) {
+      notifyError(`저장하지 못했습니다. ${errorMessageOf(err)}`);
     }
   };
 
   const handleDeleteReport = async (uuid) => {
     if (!confirm('이 보고서 수기를 삭제하시겠습니까?')) return;
     try {
-      await fetch(`${apiUrl}/activity-report/${uuid}`, { method: 'DELETE' });
-    } catch (e) {
-      console.log('API delete report fallback:', e);
+      await PoPoAxios.delete(`/activity-report/${uuid}`);
+      notify('보고서 수기가 삭제되었습니다.');
+      await fetchData();
+    } catch (err) {
+      notifyError(`삭제하지 못했습니다. ${errorMessageOf(err)}`);
     }
-    setReports((prev) => prev.filter((r) => r.uuid !== uuid));
-    setMessage('보고서 수기가 삭제되었습니다.');
   };
 
   const panes = [
@@ -303,9 +241,20 @@ export default function AdminExtracurricularPage() {
       menuItem: '비교과활동 카테고리 관리',
       render: () => (
         <Tab.Pane>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginBottom: 16,
+            }}
+          >
             <Header as="h3">등록된 비교과활동 ({activities.length}개)</Header>
-            <Button color="blue" icon labelPosition="left" onClick={() => handleOpenActModal()}>
+            <Button
+              color="blue"
+              icon
+              labelPosition="left"
+              onClick={() => handleOpenActModal()}
+            >
               <Icon name="add" />
               신규 비교과활동 추가
             </Button>
@@ -326,7 +275,9 @@ export default function AdminExtracurricularPage() {
               {activities.map((act) => (
                 <Table.Row key={act.uuid}>
                   <Table.Cell>{act.category}</Table.Cell>
-                  <Table.Cell style={{ fontWeight: 'bold' }}>{act.title}</Table.Cell>
+                  <Table.Cell style={{ fontWeight: 'bold' }}>
+                    {act.title}
+                  </Table.Cell>
                   <Table.Cell>{act.period}</Table.Cell>
                   <Table.Cell>{act.target}</Table.Cell>
                   <Table.Cell>
@@ -353,9 +304,20 @@ export default function AdminExtracurricularPage() {
       menuItem: '활동 보고서 / 수기 관리',
       render: () => (
         <Tab.Pane>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginBottom: 16,
+            }}
+          >
             <Header as="h3">등록된 보고서 및 수기 ({reports.length}개)</Header>
-            <Button color="green" icon labelPosition="left" onClick={() => handleOpenRepModal()}>
+            <Button
+              color="green"
+              icon
+              labelPosition="left"
+              onClick={() => handleOpenRepModal()}
+            >
               <Icon name="upload" />
               신규 보고서 수기 업로드
             </Button>
@@ -376,11 +338,17 @@ export default function AdminExtracurricularPage() {
 
             <Table.Body>
               {reports.map((rep) => {
-                const linkedAct = activities.find((a) => a.uuid === rep.activityId);
+                const linkedAct = activities.find(
+                  (a) => a.uuid === rep.activityId,
+                );
                 return (
                   <Table.Row key={rep.uuid}>
-                    <Table.Cell>{linkedAct ? linkedAct.title : '미지정'}</Table.Cell>
-                    <Table.Cell style={{ fontWeight: 'bold' }}>{rep.title}</Table.Cell>
+                    <Table.Cell>
+                      {linkedAct ? linkedAct.title : '미지정'}
+                    </Table.Cell>
+                    <Table.Cell style={{ fontWeight: 'bold' }}>
+                      {rep.title}
+                    </Table.Cell>
                     <Table.Cell>{rep.period}</Table.Cell>
                     <Table.Cell>
                       {rep.major} ({rep.grade})
@@ -420,7 +388,8 @@ export default function AdminExtracurricularPage() {
             <Header.Content>
               비교과활동 백과사전 관리
               <Header.Subheader>
-                학지팀 및 총학생회 제공 비교과 프로그램 카테고리 및 학생 수기 보고서를 관리합니다.
+                학지팀 및 총학생회 제공 비교과 프로그램 카테고리 및 학생 수기
+                보고서를 관리합니다.
               </Header.Subheader>
             </Header.Content>
           </Header>
@@ -428,16 +397,23 @@ export default function AdminExtracurricularPage() {
           {message && (
             <Message
               onDismiss={() => setMessage(null)}
-              header="안내"
+              header={isError ? '오류' : '안내'}
               content={message}
-              positive
+              positive={!isError}
+              negative={isError}
             />
           )}
 
-          <Tab panes={panes} />
+          <Segment basic loading={loading} style={{ padding: 0 }}>
+            <Tab panes={panes} />
+          </Segment>
 
           {/* Activity Modal */}
-          <Modal open={isActModalOpen} onClose={() => setIsActModalOpen(false)} size="small">
+          <Modal
+            open={isActModalOpen}
+            onClose={() => setIsActModalOpen(false)}
+            size="small"
+          >
             <Modal.Header>
               {actForm.uuid ? '비교과활동 정보 수정' : '신규 비교과활동 추가'}
             </Modal.Header>
@@ -448,13 +424,17 @@ export default function AdminExtracurricularPage() {
                     label="활동명"
                     placeholder="예: 세계문화탐방대"
                     value={actForm.title}
-                    onChange={(e) => setActForm({ ...actForm, title: e.target.value })}
+                    onChange={(e) =>
+                      setActForm({ ...actForm, title: e.target.value })
+                    }
                   />
                   <Form.Select
                     label="카테고리"
                     options={categoryOptions}
                     value={actForm.category}
-                    onChange={(e, { value }) => setActForm({ ...actForm, category: value })}
+                    onChange={(e, { value }) =>
+                      setActForm({ ...actForm, category: value })
+                    }
                   />
                 </Form.Group>
 
@@ -463,13 +443,17 @@ export default function AdminExtracurricularPage() {
                     label="모집 / 시행 시기"
                     placeholder="예: 매년 하계/동계 방학 중"
                     value={actForm.period}
-                    onChange={(e) => setActForm({ ...actForm, period: e.target.value })}
+                    onChange={(e) =>
+                      setActForm({ ...actForm, period: e.target.value })
+                    }
                   />
                   <Form.Input
                     label="지원 대상"
                     placeholder="예: 학부 재학생 (평점 3.0 이상)"
                     value={actForm.target}
-                    onChange={(e) => setActForm({ ...actForm, target: e.target.value })}
+                    onChange={(e) =>
+                      setActForm({ ...actForm, target: e.target.value })
+                    }
                   />
                 </Form.Group>
 
@@ -477,14 +461,21 @@ export default function AdminExtracurricularPage() {
                   label="신청 및 선발 절차"
                   placeholder="지원서 제출 -> 서류 평가 -> 면접 전형..."
                   value={actForm.applicationMethod}
-                  onChange={(e) => setActForm({ ...actForm, applicationMethod: e.target.value })}
+                  onChange={(e) =>
+                    setActForm({
+                      ...actForm,
+                      applicationMethod: e.target.value,
+                    })
+                  }
                 />
 
                 <Form.TextArea
                   label="활동 상세 설명"
                   placeholder="프로그램 개요 및 특징 작성..."
                   value={actForm.description}
-                  onChange={(e) => setActForm({ ...actForm, description: e.target.value })}
+                  onChange={(e) =>
+                    setActForm({ ...actForm, description: e.target.value })
+                  }
                 />
               </Form>
             </Modal.Content>
@@ -497,7 +488,11 @@ export default function AdminExtracurricularPage() {
           </Modal>
 
           {/* Report Modal */}
-          <Modal open={isRepModalOpen} onClose={() => setIsRepModalOpen(false)} size="large">
+          <Modal
+            open={isRepModalOpen}
+            onClose={() => setIsRepModalOpen(false)}
+            size="large"
+          >
             <Modal.Header>
               {repForm.uuid ? '보고서 수기 수정' : '신규 보고서 수기 등록'}
             </Modal.Header>
@@ -506,15 +501,23 @@ export default function AdminExtracurricularPage() {
                 <Form.Group widths="equal">
                   <Form.Select
                     label="연관 비교과활동"
-                    options={activities.map((a) => ({ key: a.uuid, text: a.title, value: a.uuid }))}
+                    options={activities.map((a) => ({
+                      key: a.uuid,
+                      text: a.title,
+                      value: a.uuid,
+                    }))}
                     value={repForm.activityId}
-                    onChange={(e, { value }) => setRepForm({ ...repForm, activityId: value })}
+                    onChange={(e, { value }) =>
+                      setRepForm({ ...repForm, activityId: value })
+                    }
                   />
                   <Form.Input
                     label="수기/보고서 제목"
                     placeholder="예: 2025 유럽 탄소중립 교통 탐방 보고서"
                     value={repForm.title}
-                    onChange={(e) => setRepForm({ ...repForm, title: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, title: e.target.value })
+                    }
                   />
                 </Form.Group>
 
@@ -523,25 +526,33 @@ export default function AdminExtracurricularPage() {
                     label="수행 시기"
                     placeholder="예: 2025학년도 하계"
                     value={repForm.period}
-                    onChange={(e) => setRepForm({ ...repForm, period: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, period: e.target.value })
+                    }
                   />
                   <Form.Input
                     label="전공"
                     placeholder="예: 컴퓨터공학과"
                     value={repForm.major}
-                    onChange={(e) => setRepForm({ ...repForm, major: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, major: e.target.value })
+                    }
                   />
                   <Form.Input
                     label="학년"
                     placeholder="예: 3학년"
                     value={repForm.grade}
-                    onChange={(e) => setRepForm({ ...repForm, grade: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, grade: e.target.value })
+                    }
                   />
                   <Form.Input
                     label="작성자 (익명)"
                     placeholder="예: 김*훈"
                     value={repForm.author}
-                    onChange={(e) => setRepForm({ ...repForm, author: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, author: e.target.value })
+                    }
                   />
                 </Form.Group>
 
@@ -550,13 +561,17 @@ export default function AdminExtracurricularPage() {
                     label="첨부 파일명"
                     placeholder="예: 2025_세계문화탐방대_보고서.pdf"
                     value={repForm.fileName}
-                    onChange={(e) => setRepForm({ ...repForm, fileName: e.target.value })}
+                    onChange={(e) =>
+                      setRepForm({ ...repForm, fileName: e.target.value })
+                    }
                   />
                   <Form.Select
                     label="파일 확장자"
                     options={fileTypeOptions}
                     value={repForm.fileType}
-                    onChange={(e, { value }) => setRepForm({ ...repForm, fileType: value })}
+                    onChange={(e, { value }) =>
+                      setRepForm({ ...repForm, fileType: value })
+                    }
                   />
                 </Form.Group>
 
@@ -564,14 +579,18 @@ export default function AdminExtracurricularPage() {
                   label="후배에게 한마디 (지원 및 준비 노하우)"
                   placeholder="후배들을 위한 실질적인 서류/면접 준비 조언..."
                   value={repForm.wordsToJuniors}
-                  onChange={(e) => setRepForm({ ...repForm, wordsToJuniors: e.target.value })}
+                  onChange={(e) =>
+                    setRepForm({ ...repForm, wordsToJuniors: e.target.value })
+                  }
                 />
 
                 <Form.TextArea
                   label="AI 보고서 요약"
                   placeholder="보고서의 핵심 요약 내용..."
                   value={repForm.aiSummary}
-                  onChange={(e) => setRepForm({ ...repForm, aiSummary: e.target.value })}
+                  onChange={(e) =>
+                    setRepForm({ ...repForm, aiSummary: e.target.value })
+                  }
                 />
               </Form>
             </Modal.Content>

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import {
   Button,
@@ -35,11 +35,13 @@ const toCategoryOptions = (activities, extra) => {
     .map((c) => ({ key: c, text: c, value: c }));
 };
 
-const fileTypeOptions = [
-  { key: 'pdf', text: 'PDF', value: 'pdf' },
-  { key: 'docx', text: 'DOCX', value: 'docx' },
-  { key: 'hwpx', text: 'HWPX', value: 'hwpx' },
-];
+const ACCEPTED_EXTENSIONS = ['pdf', 'docx', 'doc', 'hwpx', 'hwp'];
+
+/** "2025_보고서.docx" -> "2025_보고서" */
+const baseNameOf = (fileName) => {
+  const idx = fileName.lastIndexOf('.');
+  return idx === -1 ? fileName : fileName.slice(0, idx);
+};
 
 export default function AdminExtracurricularPage() {
   const [activities, setActivities] = useState([]);
@@ -79,11 +81,36 @@ export default function AdminExtracurricularPage() {
     grade: '3학년',
     major: '',
     author: '',
-    wordsToJuniors: '',
-    aiSummary: '',
+    memo: '',
     fileName: '',
-    fileType: 'pdf',
   });
+  // 업로드 대기 중인 실제 File 객체. 수정 시 비어 있으면 기존 파일을 유지한다.
+  const [pickedFile, setPickedFile] = useState(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef(null);
+
+  /** 파일을 고르면 제목을 확장자 뺀 파일명으로 자동 채운다. */
+  const applyPickedFile = (file) => {
+    if (!file) return;
+    setPickedFile(file);
+    setRepForm((prev) => ({
+      ...prev,
+      fileName: file.name,
+      title: prev.title || baseNameOf(file.name),
+    }));
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setIsDragging(false);
+    applyPickedFile(e.dataTransfer.files?.[0]);
+  };
+
+  const closeRepModal = () => {
+    setIsRepModalOpen(false);
+    setPickedFile(null);
+    setIsDragging(false);
+  };
 
   useEffect(() => {
     fetchData();
@@ -173,21 +200,30 @@ export default function AdminExtracurricularPage() {
 
   // Report Handlers
   const handleOpenRepModal = (rep = null) => {
+    setPickedFile(null);
     if (rep) {
-      setRepForm(rep);
+      setRepForm({
+        uuid: rep.uuid,
+        activityId: rep.activityId ?? '',
+        title: rep.title ?? '',
+        period: rep.period ?? '',
+        grade: rep.grade ?? '',
+        major: rep.major ?? '',
+        author: rep.author ?? '',
+        memo: rep.memo ?? '',
+        fileName: rep.fileName ?? '',
+      });
     } else {
       setRepForm({
         uuid: '',
         activityId: activities[0]?.uuid || '',
         title: '',
-        period: '2025학년도 하계',
-        grade: '3학년',
+        period: '',
+        grade: '',
         major: '',
         author: '',
-        wordsToJuniors: '',
-        aiSummary: '',
+        memo: '',
         fileName: '',
-        fileType: 'pdf',
       });
     }
     setIsRepModalOpen(true);
@@ -200,18 +236,25 @@ export default function AdminExtracurricularPage() {
     }
 
     const { uuid } = repForm;
-    const payload = {
-      activityId: repForm.activityId,
-      title: repForm.title,
-      period: repForm.period,
-      grade: repForm.grade,
-      major: repForm.major,
-      author: repForm.author,
-      wordsToJuniors: repForm.wordsToJuniors,
-      aiSummary: repForm.aiSummary,
-      fileName: repForm.fileName,
-      fileType: repForm.fileType,
-    };
+    if (!uuid && !pickedFile) {
+      alert('원본 문서를 첨부해주세요.');
+      return;
+    }
+
+    // 파일과 함께 보내야 하므로 multipart/form-data 로 전송한다.
+    const payload = new FormData();
+    for (const key of [
+      'activityId',
+      'title',
+      'period',
+      'grade',
+      'major',
+      'author',
+      'memo',
+    ]) {
+      payload.append(key, repForm[key] ?? '');
+    }
+    if (pickedFile) payload.append('file', pickedFile);
 
     try {
       if (uuid) {
@@ -221,7 +264,7 @@ export default function AdminExtracurricularPage() {
         await PoPoAxios.post('/activity-report', payload);
         notify('신규 보고서 수기가 등록되었습니다.');
       }
-      setIsRepModalOpen(false);
+      closeRepModal();
       await fetchData();
     } catch (err) {
       notifyError(`저장하지 못했습니다. ${errorMessageOf(err)}`);
@@ -498,11 +541,7 @@ export default function AdminExtracurricularPage() {
           </Modal>
 
           {/* Report Modal */}
-          <Modal
-            open={isRepModalOpen}
-            onClose={() => setIsRepModalOpen(false)}
-            size="large"
-          >
+          <Modal open={isRepModalOpen} onClose={closeRepModal} size="large">
             <Modal.Header>
               {repForm.uuid ? '보고서 수기 수정' : '신규 보고서 수기 등록'}
             </Modal.Header>
@@ -566,46 +605,62 @@ export default function AdminExtracurricularPage() {
                   />
                 </Form.Group>
 
-                <Form.Group widths="equal">
-                  <Form.Input
-                    label="첨부 파일명"
-                    placeholder="예: 2025_세계문화탐방대_보고서.pdf"
-                    value={repForm.fileName}
-                    onChange={(e) =>
-                      setRepForm({ ...repForm, fileName: e.target.value })
-                    }
+                <Form.Field>
+                  <label>원본 문서</label>
+                  <DropZone
+                    dragging={isDragging}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setIsDragging(true);
+                    }}
+                    onDragLeave={() => setIsDragging(false)}
+                    onDrop={handleDrop}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <Icon name="cloud upload" size="big" />
+                    {pickedFile ? (
+                      <>
+                        <strong>{pickedFile.name}</strong>
+                        <small>
+                          {(pickedFile.size / 1024 / 1024).toFixed(2)} MB · 다시
+                          끌어다 놓으면 교체됩니다
+                        </small>
+                      </>
+                    ) : repForm.fileName ? (
+                      <>
+                        <strong>{repForm.fileName}</strong>
+                        <small>
+                          이미 등록된 파일입니다. 교체하려면 새 파일을 올리세요
+                        </small>
+                      </>
+                    ) : (
+                      <>
+                        <strong>여기로 파일을 끌어다 놓으세요</strong>
+                        <small>또는 클릭해서 찾아보기 (PDF, DOCX, HWPX)</small>
+                      </>
+                    )}
+                  </DropZone>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept={ACCEPTED_EXTENSIONS.map((e) => `.${e}`).join(',')}
+                    hidden
+                    onChange={(e) => applyPickedFile(e.target.files?.[0])}
                   />
-                  <Form.Select
-                    label="파일 확장자"
-                    options={fileTypeOptions}
-                    value={repForm.fileType}
-                    onChange={(e, { value }) =>
-                      setRepForm({ ...repForm, fileType: value })
-                    }
-                  />
-                </Form.Group>
+                </Form.Field>
 
                 <Form.TextArea
-                  label="후배에게 한마디 (지원 및 준비 노하우)"
-                  placeholder="후배들을 위한 실질적인 서류/면접 준비 조언..."
-                  value={repForm.wordsToJuniors}
+                  label="메모"
+                  placeholder="관리자 메모 (선택)"
+                  value={repForm.memo}
                   onChange={(e) =>
-                    setRepForm({ ...repForm, wordsToJuniors: e.target.value })
-                  }
-                />
-
-                <Form.TextArea
-                  label="AI 보고서 요약"
-                  placeholder="보고서의 핵심 요약 내용..."
-                  value={repForm.aiSummary}
-                  onChange={(e) =>
-                    setRepForm({ ...repForm, aiSummary: e.target.value })
+                    setRepForm({ ...repForm, memo: e.target.value })
                   }
                 />
               </Form>
             </Modal.Content>
             <Modal.Actions>
-              <Button onClick={() => setIsRepModalOpen(false)}>취소</Button>
+              <Button onClick={closeRepModal}>취소</Button>
               <Button positive onClick={handleSaveReport}>
                 저장
               </Button>
@@ -621,4 +676,35 @@ const Container = styled.div`
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
+`;
+
+const DropZone = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 28px 16px;
+  border: 2px dashed ${(props) => (props.dragging ? '#2185d0' : '#c8cbcf')};
+  border-radius: 8px;
+  background-color: ${(props) => (props.dragging ? '#f0f7ff' : '#fafafa')};
+  color: #5b6169;
+  text-align: center;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+
+  &:hover {
+    border-color: #2185d0;
+  }
+
+  strong {
+    color: #1b1c1d;
+    word-break: break-all;
+  }
+
+  small {
+    color: #767b82;
+  }
 `;

--- a/pages/extracurricular/index.jsx
+++ b/pages/extracurricular/index.jsx
@@ -1,0 +1,595 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import {
+  Button,
+  Table,
+  Modal,
+  Form,
+  Input,
+  TextArea,
+  Select,
+  Header,
+  Segment,
+  Tab,
+  Icon,
+  Message,
+} from 'semantic-ui-react';
+import Navbar from '../../components/navbar/navbar';
+
+const categoryOptions = [
+  { key: 'global', text: '글로벌/해외', value: '글로벌/해외' },
+  { key: 'academic', text: '학술/연구', value: '학술/연구' },
+  { key: 'volunteer', text: '봉사/사회공헌', value: '봉사/사회공헌' },
+  { key: 'startup', text: '창업/취업', value: '창업/취업' },
+];
+
+const fileTypeOptions = [
+  { key: 'pdf', text: 'PDF', value: 'pdf' },
+  { key: 'docx', text: 'DOCX', value: 'docx' },
+  { key: 'hwpx', text: 'HWPX', value: 'hwpx' },
+];
+
+const INITIAL_ACTIVITIES = [
+  {
+    uuid: 'act-01',
+    title: '세계문화탐방대',
+    period: '매년 하계/동계 방학 중 (연 2회)',
+    target: '학부 재학생 (직전 학기 평점 3.0 이상)',
+    applicationMethod: '지원서 및 탐방 계획서 작성 후 포털 접수 -> 서류 심사 -> 면접 전형',
+    description: '학생들이 직접 탐방 주제와 국가를 선정하고 문화, 사회, 학문 분야의 연구 과제를 직접 체험하고 분석하는 글로벌 도전 프로그램입니다.',
+    category: '글로벌/해외',
+  },
+  {
+    uuid: 'act-02',
+    title: '노벨 위크 탐방단',
+    period: '매년 10월 ~ 11월 중 모집',
+    target: '이공계열 및 인문사회계열 학부 2~4학년',
+    applicationMethod: '노벨상 관련 에세이 제출 -> 심사 -> 학과장 추천 및 면접',
+    description: '스웨덴 스톡홀름에서 열리는 노벨상 시상식 주간에 현지를 방문하여 노벨 재단 강연 참석, 스웨덴 명문대 학생들과의 학술 교류 등을 진행하는 최고 권위의 학술 탐방 프로그램입니다.',
+    category: '학술/연구',
+  },
+];
+
+const INITIAL_REPORTS = [
+  {
+    uuid: 'rep-01',
+    activityId: 'act-01',
+    title: '유럽 친환경 도시 설계 및 탄소중립 교통 시스템 탐방 보고서',
+    period: '2025학년도 하계',
+    grade: '3학년',
+    major: '도시공학과',
+    author: '민*우',
+    wordsToJuniors: '현지 전문가 인터뷰나 기관 방문 메일을 최소 한 달 전부터 꼼꼼히 보내두는 게 좋습니다.',
+    aiSummary: '독일 프라이부르크와 네덜란드 암스테르담의 친환경 대중교통 인프라 탐방 결과 보고서.',
+    fileName: '2025_하계_세계문화탐방대_유럽교통보고서.pdf',
+    fileType: 'pdf',
+  },
+];
+
+export default function AdminExtracurricularPage() {
+  const [activities, setActivities] = useState(INITIAL_ACTIVITIES);
+  const [reports, setReports] = useState(INITIAL_REPORTS);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState(null);
+
+  // Activity Modal State
+  const [isActModalOpen, setIsActModalOpen] = useState(false);
+  const [actForm, setActForm] = useState({
+    uuid: '',
+    title: '',
+    period: '',
+    target: '',
+    applicationMethod: '',
+    description: '',
+    category: '글로벌/해외',
+  });
+
+  // Report Modal State
+  const [isRepModalOpen, setIsRepModalOpen] = useState(false);
+  const [repForm, setRepForm] = useState({
+    uuid: '',
+    activityId: '',
+    title: '',
+    period: '',
+    grade: '3학년',
+    major: '',
+    author: '',
+    wordsToJuniors: '',
+    aiSummary: '',
+    fileName: '',
+    fileType: 'pdf',
+  });
+
+  const apiUrl = process.env.NEXT_PUBLIC_API || 'https://api.popo-dev.poapper.club';
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const actRes = await fetch(`${apiUrl}/activity`);
+      if (actRes.ok) {
+        const actData = await actRes.json();
+        if (Array.isArray(actData) && actData.length > 0) {
+          setActivities(actData);
+        }
+      }
+
+      const repRes = await fetch(`${apiUrl}/activity-report`);
+      if (repRes.ok) {
+        const repData = await repRes.json();
+        if (Array.isArray(repData) && repData.length > 0) {
+          setReports(repData);
+        }
+      }
+    } catch (err) {
+      console.log('Failed fetching admin data from API, using state fallback:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Activity Handlers
+  const handleOpenActModal = (act = null) => {
+    if (act) {
+      setActForm(act);
+    } else {
+      setActForm({
+        uuid: '',
+        title: '',
+        period: '',
+        target: '',
+        applicationMethod: '',
+        description: '',
+        category: '글로벌/해외',
+      });
+    }
+    setIsActModalOpen(true);
+  };
+
+  const handleSaveActivity = async () => {
+    if (!actForm.title || !actForm.period) {
+      alert('활동명과 모집 시기는 필수 항목입니다.');
+      return;
+    }
+
+    try {
+      if (actForm.uuid) {
+        // Update
+        const res = await fetch(`${apiUrl}/activity/${actForm.uuid}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(actForm),
+        });
+        if (res.ok) {
+          setMessage('비교과활동 정보가 수정되었습니다.');
+        }
+        setActivities((prev) =>
+          prev.map((a) => (a.uuid === actForm.uuid ? { ...a, ...actForm } : a))
+        );
+      } else {
+        // Create
+        const newUuid = `act-${Date.now()}`;
+        const newAct = { ...actForm, uuid: newUuid };
+        const res = await fetch(`${apiUrl}/activity`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(newAct),
+        });
+        if (res.ok) {
+          const created = await res.json();
+          setActivities((prev) => [created, ...prev]);
+        } else {
+          setActivities((prev) => [newAct, ...prev]);
+        }
+        setMessage('신규 비교과활동이 등록되었습니다.');
+      }
+    } catch (err) {
+      console.log('API call fallback during save:', err);
+      const newUuid = actForm.uuid || `act-${Date.now()}`;
+      setActivities((prev) => {
+        const exists = prev.some((a) => a.uuid === newUuid);
+        if (exists) {
+          return prev.map((a) => (a.uuid === newUuid ? { ...a, ...actForm } : a));
+        }
+        return [{ ...actForm, uuid: newUuid }, ...prev];
+      });
+      setMessage('저장되었습니다 (로컬 상태 반영).');
+    } finally {
+      setIsActModalOpen(false);
+    }
+  };
+
+  const handleDeleteActivity = async (uuid) => {
+    if (!confirm('정말 이 비교과활동을 삭제하시겠습니까? 연결된 보고서도 함께 삭제될 수 있습니다.'))
+      return;
+    try {
+      await fetch(`${apiUrl}/activity/${uuid}`, { method: 'DELETE' });
+    } catch (e) {
+      console.log('API delete fallback:', e);
+    }
+    setActivities((prev) => prev.filter((a) => a.uuid !== uuid));
+    setMessage('비교과활동이 삭제되었습니다.');
+  };
+
+  // Report Handlers
+  const handleOpenRepModal = (rep = null) => {
+    if (rep) {
+      setRepForm(rep);
+    } else {
+      setRepForm({
+        uuid: '',
+        activityId: activities[0]?.uuid || '',
+        title: '',
+        period: '2025학년도 하계',
+        grade: '3학년',
+        major: '',
+        author: '',
+        wordsToJuniors: '',
+        aiSummary: '',
+        fileName: '',
+        fileType: 'pdf',
+      });
+    }
+    setIsRepModalOpen(true);
+  };
+
+  const handleSaveReport = async () => {
+    if (!repForm.title || !repForm.activityId) {
+      alert('보고서 제목과 활동 선택은 필수 항목입니다.');
+      return;
+    }
+
+    try {
+      if (repForm.uuid) {
+        // Update
+        await fetch(`${apiUrl}/activity-report/${repForm.uuid}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(repForm),
+        });
+        setReports((prev) =>
+          prev.map((r) => (r.uuid === repForm.uuid ? { ...r, ...repForm } : r))
+        );
+        setMessage('보고서 수기가 수정되었습니다.');
+      } else {
+        // Create
+        const newUuid = `rep-${Date.now()}`;
+        const newRep = { ...repForm, uuid: newUuid };
+        const res = await fetch(`${apiUrl}/activity-report`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(newRep),
+        });
+        if (res.ok) {
+          const created = await res.json();
+          setReports((prev) => [created, ...prev]);
+        } else {
+          setReports((prev) => [newRep, ...prev]);
+        }
+        setMessage('신규 보고서 수기가 등록되었습니다.');
+      }
+    } catch (err) {
+      console.log('API report save fallback:', err);
+      const newUuid = repForm.uuid || `rep-${Date.now()}`;
+      setReports((prev) => {
+        const exists = prev.some((r) => r.uuid === newUuid);
+        if (exists) {
+          return prev.map((r) => (r.uuid === newUuid ? { ...r, ...repForm } : r));
+        }
+        return [{ ...repForm, uuid: newUuid }, ...prev];
+      });
+      setMessage('저장되었습니다 (로컬 상태 반영).');
+    } finally {
+      setIsRepModalOpen(false);
+    }
+  };
+
+  const handleDeleteReport = async (uuid) => {
+    if (!confirm('이 보고서 수기를 삭제하시겠습니까?')) return;
+    try {
+      await fetch(`${apiUrl}/activity-report/${uuid}`, { method: 'DELETE' });
+    } catch (e) {
+      console.log('API delete report fallback:', e);
+    }
+    setReports((prev) => prev.filter((r) => r.uuid !== uuid));
+    setMessage('보고서 수기가 삭제되었습니다.');
+  };
+
+  const panes = [
+    {
+      menuItem: '비교과활동 카테고리 관리',
+      render: () => (
+        <Tab.Pane>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+            <Header as="h3">등록된 비교과활동 ({activities.length}개)</Header>
+            <Button color="blue" icon labelPosition="left" onClick={() => handleOpenActModal()}>
+              <Icon name="add" />
+              신규 비교과활동 추가
+            </Button>
+          </div>
+
+          <Table celled striped>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>카테고리</Table.HeaderCell>
+                <Table.HeaderCell>활동명</Table.HeaderCell>
+                <Table.HeaderCell>모집/시행 시기</Table.HeaderCell>
+                <Table.HeaderCell>지원 대상</Table.HeaderCell>
+                <Table.HeaderCell style={{ width: 120 }}>관리</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+
+            <Table.Body>
+              {activities.map((act) => (
+                <Table.Row key={act.uuid}>
+                  <Table.Cell>{act.category}</Table.Cell>
+                  <Table.Cell style={{ fontWeight: 'bold' }}>{act.title}</Table.Cell>
+                  <Table.Cell>{act.period}</Table.Cell>
+                  <Table.Cell>{act.target}</Table.Cell>
+                  <Table.Cell>
+                    <Button
+                      size="tiny"
+                      icon="edit"
+                      onClick={() => handleOpenActModal(act)}
+                    />
+                    <Button
+                      size="tiny"
+                      color="red"
+                      icon="trash"
+                      onClick={() => handleDeleteActivity(act.uuid)}
+                    />
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Tab.Pane>
+      ),
+    },
+    {
+      menuItem: '활동 보고서 / 수기 관리',
+      render: () => (
+        <Tab.Pane>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+            <Header as="h3">등록된 보고서 및 수기 ({reports.length}개)</Header>
+            <Button color="green" icon labelPosition="left" onClick={() => handleOpenRepModal()}>
+              <Icon name="upload" />
+              신규 보고서 수기 업로드
+            </Button>
+          </div>
+
+          <Table celled striped>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>연관 활동</Table.HeaderCell>
+                <Table.HeaderCell>보고서 제목</Table.HeaderCell>
+                <Table.HeaderCell>수행 시기</Table.HeaderCell>
+                <Table.HeaderCell>전공 / 학년</Table.HeaderCell>
+                <Table.HeaderCell>작성자</Table.HeaderCell>
+                <Table.HeaderCell>파일명</Table.HeaderCell>
+                <Table.HeaderCell style={{ width: 120 }}>관리</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+
+            <Table.Body>
+              {reports.map((rep) => {
+                const linkedAct = activities.find((a) => a.uuid === rep.activityId);
+                return (
+                  <Table.Row key={rep.uuid}>
+                    <Table.Cell>{linkedAct ? linkedAct.title : '미지정'}</Table.Cell>
+                    <Table.Cell style={{ fontWeight: 'bold' }}>{rep.title}</Table.Cell>
+                    <Table.Cell>{rep.period}</Table.Cell>
+                    <Table.Cell>
+                      {rep.major} ({rep.grade})
+                    </Table.Cell>
+                    <Table.Cell>{rep.author}</Table.Cell>
+                    <Table.Cell>{rep.fileName}</Table.Cell>
+                    <Table.Cell>
+                      <Button
+                        size="tiny"
+                        icon="edit"
+                        onClick={() => handleOpenRepModal(rep)}
+                      />
+                      <Button
+                        size="tiny"
+                        color="red"
+                        icon="trash"
+                        onClick={() => handleDeleteReport(rep.uuid)}
+                      />
+                    </Table.Cell>
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
+        </Tab.Pane>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Navbar />
+      <Container>
+        <Segment basic style={{ marginTop: 80 }}>
+          <Header as="h2">
+            <Icon name="book" />
+            <Header.Content>
+              비교과활동 백과사전 관리
+              <Header.Subheader>
+                학지팀 및 총학생회 제공 비교과 프로그램 카테고리 및 학생 수기 보고서를 관리합니다.
+              </Header.Subheader>
+            </Header.Content>
+          </Header>
+
+          {message && (
+            <Message
+              onDismiss={() => setMessage(null)}
+              header="안내"
+              content={message}
+              positive
+            />
+          )}
+
+          <Tab panes={panes} />
+
+          {/* Activity Modal */}
+          <Modal open={isActModalOpen} onClose={() => setIsActModalOpen(false)} size="small">
+            <Modal.Header>
+              {actForm.uuid ? '비교과활동 정보 수정' : '신규 비교과활동 추가'}
+            </Modal.Header>
+            <Modal.Content>
+              <Form>
+                <Form.Group widths="equal">
+                  <Form.Input
+                    label="활동명"
+                    placeholder="예: 세계문화탐방대"
+                    value={actForm.title}
+                    onChange={(e) => setActForm({ ...actForm, title: e.target.value })}
+                  />
+                  <Form.Select
+                    label="카테고리"
+                    options={categoryOptions}
+                    value={actForm.category}
+                    onChange={(e, { value }) => setActForm({ ...actForm, category: value })}
+                  />
+                </Form.Group>
+
+                <Form.Group widths="equal">
+                  <Form.Input
+                    label="모집 / 시행 시기"
+                    placeholder="예: 매년 하계/동계 방학 중"
+                    value={actForm.period}
+                    onChange={(e) => setActForm({ ...actForm, period: e.target.value })}
+                  />
+                  <Form.Input
+                    label="지원 대상"
+                    placeholder="예: 학부 재학생 (평점 3.0 이상)"
+                    value={actForm.target}
+                    onChange={(e) => setActForm({ ...actForm, target: e.target.value })}
+                  />
+                </Form.Group>
+
+                <Form.TextArea
+                  label="신청 및 선발 절차"
+                  placeholder="지원서 제출 -> 서류 평가 -> 면접 전형..."
+                  value={actForm.applicationMethod}
+                  onChange={(e) => setActForm({ ...actForm, applicationMethod: e.target.value })}
+                />
+
+                <Form.TextArea
+                  label="활동 상세 설명"
+                  placeholder="프로그램 개요 및 특징 작성..."
+                  value={actForm.description}
+                  onChange={(e) => setActForm({ ...actForm, description: e.target.value })}
+                />
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button onClick={() => setIsActModalOpen(false)}>취소</Button>
+              <Button primary onClick={handleSaveActivity}>
+                저장
+              </Button>
+            </Modal.Actions>
+          </Modal>
+
+          {/* Report Modal */}
+          <Modal open={isRepModalOpen} onClose={() => setIsRepModalOpen(false)} size="large">
+            <Modal.Header>
+              {repForm.uuid ? '보고서 수기 수정' : '신규 보고서 수기 등록'}
+            </Modal.Header>
+            <Modal.Content scrolling>
+              <Form>
+                <Form.Group widths="equal">
+                  <Form.Select
+                    label="연관 비교과활동"
+                    options={activities.map((a) => ({ key: a.uuid, text: a.title, value: a.uuid }))}
+                    value={repForm.activityId}
+                    onChange={(e, { value }) => setRepForm({ ...repForm, activityId: value })}
+                  />
+                  <Form.Input
+                    label="수기/보고서 제목"
+                    placeholder="예: 2025 유럽 탄소중립 교통 탐방 보고서"
+                    value={repForm.title}
+                    onChange={(e) => setRepForm({ ...repForm, title: e.target.value })}
+                  />
+                </Form.Group>
+
+                <Form.Group widths="equal">
+                  <Form.Input
+                    label="수행 시기"
+                    placeholder="예: 2025학년도 하계"
+                    value={repForm.period}
+                    onChange={(e) => setRepForm({ ...repForm, period: e.target.value })}
+                  />
+                  <Form.Input
+                    label="전공"
+                    placeholder="예: 컴퓨터공학과"
+                    value={repForm.major}
+                    onChange={(e) => setRepForm({ ...repForm, major: e.target.value })}
+                  />
+                  <Form.Input
+                    label="학년"
+                    placeholder="예: 3학년"
+                    value={repForm.grade}
+                    onChange={(e) => setRepForm({ ...repForm, grade: e.target.value })}
+                  />
+                  <Form.Input
+                    label="작성자 (익명)"
+                    placeholder="예: 김*훈"
+                    value={repForm.author}
+                    onChange={(e) => setRepForm({ ...repForm, author: e.target.value })}
+                  />
+                </Form.Group>
+
+                <Form.Group widths="equal">
+                  <Form.Input
+                    label="첨부 파일명"
+                    placeholder="예: 2025_세계문화탐방대_보고서.pdf"
+                    value={repForm.fileName}
+                    onChange={(e) => setRepForm({ ...repForm, fileName: e.target.value })}
+                  />
+                  <Form.Select
+                    label="파일 확장자"
+                    options={fileTypeOptions}
+                    value={repForm.fileType}
+                    onChange={(e, { value }) => setRepForm({ ...repForm, fileType: value })}
+                  />
+                </Form.Group>
+
+                <Form.TextArea
+                  label="후배에게 한마디 (지원 및 준비 노하우)"
+                  placeholder="후배들을 위한 실질적인 서류/면접 준비 조언..."
+                  value={repForm.wordsToJuniors}
+                  onChange={(e) => setRepForm({ ...repForm, wordsToJuniors: e.target.value })}
+                />
+
+                <Form.TextArea
+                  label="AI 보고서 요약"
+                  placeholder="보고서의 핵심 요약 내용..."
+                  value={repForm.aiSummary}
+                  onChange={(e) => setRepForm({ ...repForm, aiSummary: e.target.value })}
+                />
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button onClick={() => setIsRepModalOpen(false)}>취소</Button>
+              <Button positive onClick={handleSaveReport}>
+                저장
+              </Button>
+            </Modal.Actions>
+          </Modal>
+        </Segment>
+      </Container>
+    </>
+  );
+}
+
+const Container = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+`;


### PR DESCRIPTION
## 무엇을 하는 PR인가

어드민에 **비교과활동 관리** 페이지(`/extracurricular`)를 추가합니다. 학지팀·총학생회가 비교과 프로그램과 학생 활동 수기를 등록·수정·삭제합니다.

API: PoApper/popo-nest-api#214 (먼저 배포되어야 합니다)
학생용 웹: PoApper/popo-public-web#183

## 화면

- 탭 2개 — **비교과활동 관리**, **활동 보고서 / 수기 관리**
- 네비게이션(데스크탑 메뉴 + 모바일 드롭다운)에 진입점 추가
- 활동: 활동명 / 모집 시기 / 지원 대상 / 신청 방법 / 설명 / 카테고리
- 수기: 연관 활동 / 제목 / 수행 시기 / 학년 / 전공 / 작성자 / 메모 + **원본 문서 업로드**

**문서 업로드**는 드래그 앤 드롭, 또는 클릭해서 OS 파일 탐색기로 고릅니다. 파일을 고르면 보고서 제목이 확장자를 뺀 파일명으로 자동 입력되고, 파일은 `multipart/form-data`로 전송됩니다. 파일명과 확장자를 사람이 타이핑하던 방식을 없앴습니다 — 서로 어긋날 수 있고 실제 파일은 서버에 가지도 않았습니다.

**카테고리**는 드롭다운에서 새 카테고리를 직접 입력해 추가할 수 있습니다.

## 배포 순서

1. popo-nest-api#214 의 **DDL을 dev DB에 먼저 적용** (신규 테이블 2개)
2. API 배포
3. 이 PR

DDL 전에는 활동/수기 목록이 오류로 표시됩니다.

## 검증

- `npx next lint` 통과 (이 브랜치가 건드리는 파일 기준 에러 0). pre-commit 통과.
- 로컬에서 권한별 동작 확인: 학생/자치단체 계정은 저장 시 403 오류 표시, admin·staff는 정상 저장.
- 한글 파일명 업로드 후 목록·상세에 정상 표시.

## 환경변수

변경 없습니다. `NEXT_PUBLIC_ENV`만 있으면 됩니다 (`NEXT_PUBLIC_API`는 더 이상 쓰지 않습니다).
