### PR TITLE
CI: 릴리즈 빌드에서 dev 재배포 건너뛰기

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -93,6 +93,9 @@ jobs:
   redeploy_dev_service:
     name: Redeploy Dev Service
     needs: docker_build_and_push
+    # release(=Prod 이미지 빌드) 때는 dev를 건드리지 않는다.
+    # Prod 배포는 Portainer에서 이미지 태그를 직접 바꿔주는 수동 절차다.
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Redeploy Dev Service


### PR DESCRIPTION
## 문제

`redeploy_dev_service` 잡에 조건이 없어서, **릴리즈를 publish할 때도 dev Portainer 웹훅을 호출**합니다.

릴리즈는 prod용 이미지(`vX.Y.Z`)를 만드는 동작입니다. dev 서비스는 `latest` 태그를 보므로 실제로 내용이 바뀌지는 않지만, 워크플로우 실행 결과만 보면 dev가 재배포된 것처럼 보입니다. 이어지는 `deploy_health_check`까지 돌아서, prod 릴리즈 로그에 dev 관련 잡이 섞입니다. prod 배포는 Portainer에서 사람이 이미지 태그를 바꾸는 수동 절차인데, 자동화된 무언가가 함께 도는 것처럼 오해할 여지가 있습니다.

## 바꾸는 것

```yaml
redeploy_dev_service:
  needs: docker_build_and_push
+ if: github.event_name != 'release'
```

`deploy_health_check`는 `needs: redeploy_dev_service`라서 함께 skip 됩니다. 일반 push/PR 흐름(= dev 배포)은 그대로입니다.

같은 수정을 세 저장소에 올렸습니다. `popo-public-web`은 트리거 자체가 달라서 그쪽 PR에 함께 정리했습니다: PoApper/popo-public-web#184

## 검증

로컬에서는 YAML 파싱까지만 확인했습니다. 머지 후 릴리즈를 만들 때 `Redeploy Dev Service`가 skip 되는지, 일반 PR에서는 그대로 도는지 봐주세요.
